### PR TITLE
Add ioctl support for setting GPIO1 level

### DIFF
--- a/axp192.c
+++ b/axp192.c
@@ -178,6 +178,15 @@ axp192_err_t axp192_ioctl(const axp192_t *axp, uint16_t command, uint8_t *buffer
         tmp &= ~0b00001000;
         return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
         break;
+    case AXP192_GPIO1_SET_LEVEL:
+        axp->read(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        if (*buffer) {
+            tmp |= 0b00000010;
+        } else {
+            tmp &= ~0b00000010;
+        }
+        return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        break;
     }
 
     return AXP192_ERROR_NOTTY;

--- a/axp192.h
+++ b/axp192.h
@@ -151,6 +151,11 @@ extern "C" {
 #define AXP192_LDO3_ENABLE              (0x1201)
 #define AXP192_LDO3_DISABLE             (0x1202)
 
+#define AXP192_GPIO_LOW                 (&(uint8_t){0})
+#define AXP192_GPIO_HIGH                (&(uint8_t){1})
+
+#define AXP192_GPIO1_SET_LEVEL          (0x9401)
+
 /* Error codes */
 #define AXP192_OK                       (0)
 #define AXP192_ERROR_NOTTY              (-1)


### PR DESCRIPTION
```c
axp192_ioctl(&axp, AXP192_GPIO1_SET_LEVEL, AXP192_GPIO_HIGH);
axp192_ioctl(&axp, AXP192_GPIO1_SET_LEVEL, AXP192_GPIO_LOW);
```

Note that with M5Stack Core2 pulling GPIO1 low will turn the green led on.