### PR TITLE
Add ioctl support for setting GPIO4 level

### DIFF
--- a/axp192.c
+++ b/axp192.c
@@ -179,6 +179,7 @@ axp192_err_t axp192_ioctl(const axp192_t *axp, uint16_t command, uint8_t *buffer
         return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
         break;
     case AXP192_GPIO1_SET_LEVEL:
+    case AXP192_GPIO4_SET_LEVEL:
         axp->read(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
         if (*buffer) {
             tmp |= 0b00000010;

--- a/axp192.h
+++ b/axp192.h
@@ -155,6 +155,7 @@ extern "C" {
 #define AXP192_GPIO_HIGH                (&(uint8_t){1})
 
 #define AXP192_GPIO1_SET_LEVEL          (0x9401)
+#define AXP192_GPIO4_SET_LEVEL          (0x9601)
 
 /* Error codes */
 #define AXP192_OK                       (0)


### PR DESCRIPTION
```c
axp192_ioctl(&axp, AXP192_GPIO4_SET_LEVEL, AXP192_GPIO_HIGH);
axp192_ioctl(&axp, AXP192_GPIO4_SET_LEVEL, AXP192_GPIO_LOW);
```