### PR TITLE
Add ioctl support to enable and disable LDO2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ printf("cbat: %.2fmAh", cbat);
 
 /* Misc ioctl functions. */
 
+axp192_ioctl(&axp, AXP192_LDO2_SET_CONTROL, AXP192_DISABLE);
+axp192_ioctl(&axp, AXP192_LDO2_SET_CONTROL, AXP192_ENABLE);
+
 axp192_ioctl(&axp, AXP192_LDO3_SET_CONTROL, AXP192_DISABLE);
 axp192_ioctl(&axp, AXP192_LDO3_SET_CONTROL, AXP192_ENABLE);
 

--- a/axp192.c
+++ b/axp192.c
@@ -168,6 +168,15 @@ axp192_err_t axp192_ioctl(const axp192_t *axp, uint16_t command, uint8_t *buffer
         tmp = 0b10100000;
         return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
         break;
+    case AXP192_LDO2_SET_CONTROL:
+        axp->read(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        if (*buffer) {
+            tmp |= 0b00000100;
+        } else {
+            tmp &= ~0b00000100;
+        }
+        return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        break;
     case AXP192_LDO3_SET_CONTROL:
         axp->read(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
         if (*buffer) {

--- a/axp192.h
+++ b/axp192.h
@@ -151,6 +151,7 @@ extern "C" {
 #define AXP192_DISABLE                  (&(uint8_t){0})
 #define AXP192_ENABLE                   (&(uint8_t){1})
 
+#define AXP192_LDO2_SET_CONTROL         (0x1200)
 #define AXP192_LDO3_SET_CONTROL         (0x1201)
 #define AXP192_DCDC3_SET_CONTROL        (0x1202)
 


### PR DESCRIPTION
For M5Stack Core2 this is the display logic power.

```c
axp192_ioctl(&axp, AXP192_LDO2_SET_CONTROL, AXP192_DISABLE);
axp192_ioctl(&axp, AXP192_LDO2_SET_CONTROL, AXP192_ENABLE);
```