### PR TITLE
Remove moot ioctl commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Add support for reading raw register values ([#24](https://github.com/tuupola/axp192/issues/24))
 
+### Removed
+
+- All moot ioctl commands ([#25](https://github.com/tuupola/axp192/issues/25)).
+    ```c
+    axp192_ioctl(&axp, AXP192_READ_POWER_STATUS, &power);
+    axp192_ioctl(&axp, AXP192_READ_CHARGE_STATUS, &charge);
+    ```
+    All registers can now be read using the `axp192_read()` function instead.
+
+    ```c
+    axp192_read(&axp, AXP192_POWER_STATUS, &power);
+    axp192_read(&axp, AXP192_CHARGE_STATUS, &charge);
+    ```
+
 ## [0.5.0](https://github.com/tuupola/axp192/compare/0.4.0...0.5.0) - 2021-09-03
 
 This version adds features needed for using with M5STack Core2.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ printf(
 
 /* All non ADC registers will be read as a raw bytes. */
 /* See axp192.h or datasheet for all possible registers. */
-axp192_ioctl(&axp, AXP192_READ_POWER_STATUS, &power);
-axp192_ioctl(&axp, AXP192_READ_CHARGE_STATUS, &charge);
+axp192_read(&axp, AXP192_POWER_STATUS, &power);
+axp192_read(&axp, AXP192_CHARGE_STATUS, &charge);
 
 printf("power: 0x%02x charge: 0x%02x", power, charge);
 

--- a/axp192.c
+++ b/axp192.c
@@ -172,10 +172,6 @@ axp192_err_t axp192_ioctl(const axp192_t *axp, uint16_t command, uint8_t *buffer
     uint8_t tmp;
 
     switch (command) {
-    case AXP192_READ_POWER_STATUS:
-    case AXP192_READ_CHARGE_STATUS:
-        return axp->read(axp->handle, AXP192_ADDRESS, reg, buffer, 1);
-        break;
     case AXP192_COULOMB_COUNTER_ENABLE:
         tmp = 0b10000000;
         return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);


### PR DESCRIPTION
These are removed:

```c
axp192_ioctl(&axp, AXP192_READ_POWER_STATUS, &power);
axp192_ioctl(&axp, AXP192_READ_CHARGE_STATUS, &charge);
```

Use the following instead:

```c
axp192_read(&axp, AXP192_POWER_STATUS, &power);
axp192_read(&axp, AXP192_CHARGE_STATUS, &charge);
```