### PR TITLE
Add ioctl support for enabling and disabling DCDC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Support for reading raw register values ([#24](https://github.com/tuupola/axp192/pull/24))
 - Support for manually setting the rail voltages ([#27](https://github.com/tuupola/axp192/pull/27))
+- Support for manually enablind and disabling DCDC1 ([#29](https://github.com/tuupola/axp192/pull/29))
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ axp192_ioctl(&axp, AXP192_LDOIO0_SET_VOLTAGE, 3300);
 axp192_ioctl(&axp, AXP192_LDO2_SET_VOLTAGE, 3300);
 axp192_ioctl(&axp, AXP192_LDO3_SET_VOLTAGE, 3300);
 
-/* axp192_ioctl(&axp, AXP192_DCDC1_ENABLE); */
+axp192_ioctl(&axp, AXP192_DCDC1_ENABLE);
 /* axp192_ioctl(&axp, AXP192_DCDC2_ENABLE); */
 axp192_ioctl(&axp, AXP192_DCDC3_ENABLE);
 /* axp192_ioctl(&axp, AXP192_LDOIO0_ENABLE); */
@@ -111,21 +111,25 @@ printf("power: 0x%02x charge: 0x%02x", power, charge);
 ```c
 /* Shortcuts for common tasks which otherwise would require */
 /* multiple steps or function calls. */
-axp192_ioctl(&axp, AXP192_LDO2_ENABLE);
-axp192_ioctl(&axp, AXP192_LDO2_DISABLE);
-
-axp192_ioctl(&axp, AXP192_LDO3_ENABLE);
-axp192_ioctl(&axp, AXP192_LDO3_DISABLE);
-
-axp192_ioctl(&axp, AXP192_DCDC3_ENABLE);
-axp192_ioctl(&axp, AXP192_DCDC3_DISABLE);
-
 axp192_ioctl(&axp, AXP192_DCDC1_SET_VOLTAGE, 3300);
 axp192_ioctl(&axp, AXP192_DCDC2_SET_VOLTAGE, 2275);
 axp192_ioctl(&axp, AXP192_DCDC3_SET_VOLTAGE, 3300);
 axp192_ioctl(&axp, AXP192_LDOIO0_SET_VOLTAGE, 3300);
 axp192_ioctl(&axp, AXP192_LDO2_SET_VOLTAGE, 3300);
 axp192_ioctl(&axp, AXP192_LDO3_SET_VOLTAGE, 3300);
+
+axp192_ioctl(&axp, AXP192_LDO2_ENABLE);
+axp192_ioctl(&axp, AXP192_LDO2_DISABLE);
+
+axp192_ioctl(&axp, AXP192_LDO3_ENABLE);
+axp192_ioctl(&axp, AXP192_LDO3_DISABLE);
+
+/* Do not disable DCDC1 unless you know what you are doing. */
+axp192_ioctl(&axp, AXP192_DCDC1_ENABLE);
+axp192_ioctl(&axp, AXP192_DCDC1_DISABLE);
+
+axp192_ioctl(&axp, AXP192_DCDC3_ENABLE);
+axp192_ioctl(&axp, AXP192_DCDC3_DISABLE);
 
 axp192_ioctl(&axp, AXP192_GPIO0_SET_LEVEL, AXP192_HIGH);
 axp192_ioctl(&axp, AXP192_GPIO0_SET_LEVEL, AXP192_LOW);

--- a/axp192.c
+++ b/axp192.c
@@ -227,6 +227,17 @@ axp192_err_t axp192_ioctl(const axp192_t *axp, int command, ...)
         tmp &= ~0b00001000;
         return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
         break;
+    case AXP192_DCDC1_ENABLE:
+        axp->read(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        tmp |= 0b00000001;
+        return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        break;
+    /* This is currently untested. */
+    case AXP192_DCDC1_DISABLE:
+        axp->read(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        tmp &= ~0b00000001;
+        return axp->write(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
+        break;
     case AXP192_DCDC3_ENABLE:
         axp->read(axp->handle, AXP192_ADDRESS, reg, &tmp, 1);
         tmp |= 0b00000010;

--- a/axp192.h
+++ b/axp192.h
@@ -153,8 +153,10 @@ extern "C" {
 #define AXP192_LDO2_DISABLE             (0x1201)
 #define AXP192_LDO3_ENABLE              (0x1202)
 #define AXP192_LDO3_DISABLE             (0x1203)
-#define AXP192_DCDC3_ENABLE             (0x1204)
-#define AXP192_DCDC3_DISABLE            (0x1205)
+#define AXP192_DCDC1_ENABLE             (0x1204)
+#define AXP192_DCDC1_DISABLE            (0x1205)
+#define AXP192_DCDC3_ENABLE             (0x1208)
+#define AXP192_DCDC3_DISABLE            (0x1209)
 
 #define AXP192_DCDC1_SET_VOLTAGE        (0x2600)
 #define AXP192_DCDC2_SET_VOLTAGE        (0x2300)


### PR DESCRIPTION
This usually powers the MCU so do not disable unless you know what you are doing.

```c
axp192_ioctl(&axp, AXP192_DCDC1_ENABLE);
axp192_ioctl(&axp, AXP192_DCDC1_DISABLE);
```