### PR TITLE
Enable all outputs by default (fixes #34)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -3,18 +3,25 @@ menu "Power system configuration (AXP192)"
 menu "Output control"
     config AXP192_DCDC13_LDO23_CONTROL_BIT6_SELECTED
         bool "Enable EXTEN"
+        default y
     config AXP192_DCDC13_LDO23_CONTROL_BIT4_SELECTED
         bool "Enable DC-DC2"
+        default y
     config AXP192_DCDC13_LDO23_CONTROL_BIT3_SELECTED
         bool "Enable LDO3"
+        default y
     config AXP192_DCDC13_LDO23_CONTROL_BIT2_SELECTED
         bool "Enable LDO2"
+        default y
     config AXP192_GPIO0_CONTROL_LDOIO0_SELECTED
         bool "Enable LDOIO0"
+        default y
     config AXP192_DCDC13_LDO23_CONTROL_BIT1_SELECTED
         bool "Enable DC-DC3"
+        default y
     config AXP192_DCDC13_LDO23_CONTROL_BIT0_SELECTED
         bool "Enable DC-DC1"
+        default y
 endmenu
 
 config AXP192_EXTEN_DCDC2_CONTROL_BIT2


### PR DESCRIPTION
Make sure all outputs are enabled by default to avoid accidental bricking of boards.